### PR TITLE
(refactor) additional env for kafka experiment

### DIFF
--- a/feature-demos/kafka-chaos-examples/kafka-broker-pod-failure/README.md
+++ b/feature-demos/kafka-chaos-examples/kafka-broker-pod-failure/README.md
@@ -124,6 +124,10 @@ spec:
           - name: KAFKA_PORT
             value: '9092'
 
+          # in milliseconds  
+          - name: KAFKA_CONSUMER_TIMEOUT
+            value: '70000'
+
           # ensure to set the instance name if using KUDO operator
           - name: KAFKA_INSTANCE_NAME
             value: ''

--- a/feature-demos/kafka-chaos-examples/kafka-broker-pod-failure/chaosengine-confluent.yaml
+++ b/feature-demos/kafka-chaos-examples/kafka-broker-pod-failure/chaosengine-confluent.yaml
@@ -35,6 +35,10 @@ spec:
           - name: KAFKA_PORT
             value: '9092'
 
+          # in milliseconds  
+          - name: KAFKA_CONSUMER_TIMEOUT
+            value: '70000'
+
           - name: ZOOKEEPER_NAMESPACE
             value: 'default'
 

--- a/feature-demos/kafka-chaos-examples/kafka-broker-pod-failure/chaosengine-kudo.yaml
+++ b/feature-demos/kafka-chaos-examples/kafka-broker-pod-failure/chaosengine-kudo.yaml
@@ -35,6 +35,10 @@ spec:
           - name: KAFKA_PORT
             value: '9092'
 
+          # in milliseconds  
+          - name: KAFKA_CONSUMER_TIMEOUT
+            value: '30000'
+
           # ensure to set the instance name if using KUDO operator
           - name: KAFKA_INSTANCE_NAME
             value: 'kafka'


### PR DESCRIPTION
Signed-off-by: ksatchit <ksatchit@mayadata.io>

- Adds KAFKA_CONSUMER_TIMEOUT ENV defaults: 
  - kudo: 30000 ms
  - confluent: 70000 ms